### PR TITLE
shorten file path. ...

### DIFF
--- a/apps/front/modules/default/templates/_breadcrumb.php
+++ b/apps/front/modules/default/templates/_breadcrumb.php
@@ -38,7 +38,7 @@
       <?php $fileNeedList = sizeof($fileBreadCrumbList) ?>
       <li class="selected<?php echo $fileNeedList ? ' dropdown' : '' ?>">
         <span class="ricon">E</span>
-        <?php echo link_to($currentBreadCrumbFile, 'default/file?file=' . $currentBreadCrumbFile->getId()) ?>
+        <?php echo link_to(stringUtils::shortenFilePath($currentBreadCrumbFile), 'default/file?file=' . $currentBreadCrumbFile->getId(), array('class' => 'tooltip', 'title' => $currentBreadCrumbFile)) ?>
         <?php if($fileNeedList): ?>
           <?php echo link_to('@', '@homepage', array('class' => 'dropdown-toggle')) ?>
           <ul class="dropdown-menu">

--- a/lib/utils/stringUtils.class.php
+++ b/lib/utils/stringUtils.class.php
@@ -58,4 +58,38 @@ class stringUtils {
   {
     return preg_replace('/^refs #(\d)+ (:[ ]*)?/i', '', $str);
   }
+
+  /***
+   * Shorten file path if too long
+   *
+   * if filename (excluding directories) is too long, this will return file[...]name.php
+   * if path directory is too long this will return foo/ba[...]az/filename.php
+   *
+   * @static
+   *
+   * @param string $path   file path to shorten
+   * @param int    $length file path max length
+   * @param string $with
+   * @param int    $at     number of character before splitting with $with
+   *
+   * @return string
+   */
+  public static function shortenFilePath($path, $length = 100, $with = '[...]', $at = 20)
+  {
+    if (strlen($path) < $length)
+    {
+      return $path;
+    }
+
+    $fileName       = basename($path);
+    $fileNameLength = strlen($fileName);
+    if ($fileNameLength > $length)
+    {
+      return sprintf('%s%s%s', substr($fileName, 0, $at), $with, substr($fileName, -($length - strlen($with) - $at)));
+    }
+
+    $dirName = dirname($path);
+
+    return sprintf('%s%s%s%s', substr($dirName, 0, $at), $with, substr($dirName, -($length - $fileNameLength - strlen($with) - $at)), $fileName);
+  }
 }


### PR DESCRIPTION
When file path is too long, breadcrumb overrides the button bar in the file view.

also display complete path in tooltip
