### PR TITLE
increase memory limit in init task

### DIFF
--- a/lib/task/initTask.class.php
+++ b/lib/task/initTask.class.php
@@ -24,6 +24,7 @@ EOF;
 
   protected function execute($arguments = array(), $options = array())
   {
+    ini_set('memory_limit', '64M');
     // initialize the database connection
     $databaseManager = new sfDatabaseManager($this->configuration);
     $connection = $databaseManager->getDatabase($options['connection'])->getConnection();


### PR DESCRIPTION
the memory_limit was reach by propel during init if it was
set to 32M.
 memory_mimit setted to 64M in init task.
 closes #51
