### PR TITLE
fix xmpp notifier fix xmpp notifier fix xmpp notifier Fix xmpp notifier

### DIFF
--- a/config/notifiers.yml.dist
+++ b/config/notifiers.yml.dist
@@ -39,6 +39,6 @@ XmppNotifier:
       password: password
       ressource: xmpphp
       server: jabber.yourdomain.com
-      to: team-chatroom@conference.jabber.yourdomain.com/Crew
+      to: team-chatroom@conference.jabber.yourdomain.com
       type: groupchat
 

--- a/lib/notifiers/XmppNotifier.class.php
+++ b/lib/notifiers/XmppNotifier.class.php
@@ -29,14 +29,14 @@ class XmppNotifier extends SimpleNotifier
     $ressource = $configCurrentProject['ressource'];
     $server    = $configCurrentProject['server'];
     $to        = $configCurrentProject['to'];
-    $type      = $configCurrentProject['groupchat'];
+    $type      = $configCurrentProject['type'];
 
     $xmpp = new XMPPHP_XMPP($host, $port, $user, $password, $ressource, $server, false, 4);
     $xmpp->connect();
     $xmpp->processUntil('session_start');
-    $xmpp->presence(null, 'available', $to);
+    $xmpp->presence(null, 'available', $to . '/' . $user);
     $xmpp->message($to, $message, $type);
-    $xmpp->presence(null, 'unavailable', $to);
+    $xmpp->presence(null, 'unavailable', $to . '/' . $user);
     $xmpp->disconnect();
 
     return $this;


### PR DESCRIPTION
- type options was not properly retrived
- chatrooms need to indicate user when sending message
