### PR TITLE
if GitCommand::cloneRepository() failed, it can returns null instead of ...

### DIFF
--- a/apps/admin/modules/default/actions/projectAddAction.class.php
+++ b/apps/admin/modules/default/actions/projectAddAction.class.php
@@ -59,14 +59,14 @@ class projectAddAction extends sfAction
           if(!is_dir($repository))
           {
             $cloneStatus = GitCommand::cloneRepository($remote, $repository);
-            if($cloneStatus == 0)
+            if($cloneStatus === 0)
             {
               $message .= sprintf(" and remote '%s' is correctly cloned in '%s'", $remote, $repository);
               $this->getUser()->setFlash('notice', $message);
             }
             else
             {
-              $message .= sprintf(" but remote '%s' is not cloned in '%s' [status : %s]", $remote, $repository, $cloneStatus);
+              $message .= sprintf(" but remote '%s' is not cloned in '%s' [status : %s]", $remote, $repository, ($cloneStatus === null ? 'NULL' : $cloneStatus));
               throw new Exception($message);
             }
           }

--- a/lib/utils/gitCommand.class.php
+++ b/lib/utils/gitCommand.class.php
@@ -172,6 +172,7 @@ class GitCommand
    */
   public static function cloneRepository($repositoryReadOnlyUrl, $path)
   {
+    $status = 0;
     GitCommand::exec(sprintf('git clone --mirror %s %s', $repositoryReadOnlyUrl, $path), $status);
     return $status;
   }

--- a/lib/utils/gitCommand.class.php
+++ b/lib/utils/gitCommand.class.php
@@ -173,7 +173,7 @@ class GitCommand
   public static function cloneRepository($repositoryReadOnlyUrl, $path)
   {
     $status = 0;
-    GitCommand::exec(sprintf('git clone --mirror %s %s', $repositoryReadOnlyUrl, $path), $status);
+    GitCommand::exec(sprintf('git clone --mirror %s %s', $repositoryReadOnlyUrl, escapeshellarg($path)), $status);
     return $status;
   }
 


### PR DESCRIPTION
...value different than 0, so success must be identical to 0, not just equal.
