### PR TITLE
Added phpide:// links to line numbers

### DIFF
--- a/apps/front/modules/default/templates/fileSuccess.php
+++ b/apps/front/modules/default/templates/fileSuccess.php
@@ -55,8 +55,12 @@
             <?php $deleledLinesCounter += substr($fileContentLine, 0, 1) == '+' ? 0 : 1; ?>
             <?php $addedLinesCounter += substr($fileContentLine, 0, 1) == '-' ? 0 : 1; ?>
             <tr id="position_<?php echo $position ?>">
-              <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '+' ? '' : $deleledLinesCounter; ?></td>
-              <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '-' ? '' : $addedLinesCounter; ?></td>
+              <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '+' ? '' :
+                link_to($deleledLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', $file->getFilename(), $deleledLinesCounter))
+              ?></td>
+              <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '-' ? '' :
+                link_to($addedLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', $file->getFilename(), $addedLinesCounter))
+              ?></td>
               <td style="width: 100%" class="line <?php echo substr($fileContentLine, 0, 1) == '-' ? 'deleted' : (substr($fileContentLine, 0, 1) == '+' ? 'added' : '') ?>">
                 <strong class="add_bubble <?php echo array_key_exists($position, $sf_data->getRaw('fileLineComments')) ? 'disabled' : 'enabled'; ?><?php echo !empty($fileLineComments[$position]) && sizeof($fileLineComments[$position]) >= 1 ? ' commented' : ''; ?>" data="<?php echo url_for('default/commentAddLine') ?>?commit=<?php echo $file->getLastChangeCommit() ?>&fileId=<?php echo $file->getId() ?>&position=<?php echo $position ?>&line=<?php echo substr($fileContentLine, 0, 1) == '-' ? $deleledLinesCounter : $addedLinesCounter ?>"><span class="ricon">P</span> <span class="ricon">@</span></strong>
                 <pre><?php echo sprintf(" <strong>%s</strong> %s", substr($fileContentLine, 0, 1), substr($fileContentLine, 1)); ?></pre>

--- a/apps/front/modules/default/templates/fileSuccess.php
+++ b/apps/front/modules/default/templates/fileSuccess.php
@@ -56,10 +56,10 @@
             <?php $addedLinesCounter += substr($fileContentLine, 0, 1) == '-' ? 0 : 1; ?>
             <tr id="position_<?php echo $position ?>">
               <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '+' ? '' :
-                link_to($deleledLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', esc_specialchars($file->getFilename()), $deleledLinesCounter))
+                sprintf('<a href="crewide://%s@%s@%d">%d</a>', urlencode($repository->getName()), urlencode($file->getFilename()), $deleledLinesCounter, $deleledLinesCounter)
               ?></td>
               <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '-' ? '' :
-                link_to($addedLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', esc_specialchars($file->getFilename()), $addedLinesCounter))
+                sprintf('<a href="crewide://%s@%s@%d">%d</a>', urlencode($repository->getName()), urlencode($file->getFilename()), $addedLinesCounter, $addedLinesCounter)
               ?></td>
               <td style="width: 100%" class="line <?php echo substr($fileContentLine, 0, 1) == '-' ? 'deleted' : (substr($fileContentLine, 0, 1) == '+' ? 'added' : '') ?>">
                 <strong class="add_bubble <?php echo array_key_exists($position, $sf_data->getRaw('fileLineComments')) ? 'disabled' : 'enabled'; ?><?php echo !empty($fileLineComments[$position]) && sizeof($fileLineComments[$position]) >= 1 ? ' commented' : ''; ?>" data="<?php echo url_for('default/commentAddLine') ?>?commit=<?php echo $file->getLastChangeCommit() ?>&fileId=<?php echo $file->getId() ?>&position=<?php echo $position ?>&line=<?php echo substr($fileContentLine, 0, 1) == '-' ? $deleledLinesCounter : $addedLinesCounter ?>"><span class="ricon">P</span> <span class="ricon">@</span></strong>

--- a/apps/front/modules/default/templates/fileSuccess.php
+++ b/apps/front/modules/default/templates/fileSuccess.php
@@ -56,10 +56,10 @@
             <?php $addedLinesCounter += substr($fileContentLine, 0, 1) == '-' ? 0 : 1; ?>
             <tr id="position_<?php echo $position ?>">
               <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '+' ? '' :
-                link_to($deleledLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', $file->getFilename(), $deleledLinesCounter))
+                link_to($deleledLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', esc_specialchars($file->getFilename()), $deleledLinesCounter))
               ?></td>
               <td class="line_numbers"><?php echo substr($fileContentLine, 0, 1) == '-' ? '' :
-                link_to($addedLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', $file->getFilename(), $addedLinesCounter))
+                link_to($addedLinesCounter, sprintf('phpide://_PROJECTROOT_/%s@%d', esc_specialchars($file->getFilename()), $addedLinesCounter))
               ?></td>
               <td style="width: 100%" class="line <?php echo substr($fileContentLine, 0, 1) == '-' ? 'deleted' : (substr($fileContentLine, 0, 1) == '+' ? 'added' : '') ?>">
                 <strong class="add_bubble <?php echo array_key_exists($position, $sf_data->getRaw('fileLineComments')) ? 'disabled' : 'enabled'; ?><?php echo !empty($fileLineComments[$position]) && sizeof($fileLineComments[$position]) >= 1 ? ' commented' : ''; ?>" data="<?php echo url_for('default/commentAddLine') ?>?commit=<?php echo $file->getLastChangeCommit() ?>&fileId=<?php echo $file->getId() ?>&position=<?php echo $position ?>&line=<?php echo substr($fileContentLine, 0, 1) == '-' ? $deleledLinesCounter : $addedLinesCounter ?>"><span class="ricon">P</span> <span class="ricon">@</span></strong>


### PR DESCRIPTION
Line numbers in the left margin are now
hyperlinks to

```
phpide://_PROJECTROOT_/file@linenum
```

With `'file'` being the real path to the file
in the project, and linenum being the line number.

This will allow users to click on a line number and
have the corresponding file opened on the rigth line
in the IDE.
All they have to do is to configure their browser to
open `phpide://` links with a specific script, that will
extract file + line, and run their IDE, passing it
those parameters as it expects.

Note : the project's root is different on each developer's
computer -- and, so, it's their local script that has to
replace `'_PROJECTROOT_'` by the right actual project root.

This should, more or less, fix issue #10
