### PR TITLE
refs #105 fix double escaping of GitCommand->getCommitInfos

### DIFF
--- a/lib/git/GitCommand.class.php
+++ b/lib/git/GitCommand.class.php
@@ -187,7 +187,7 @@ class GitCommand
 
   public function getCommitInfos($gitDir, $commit, $format)
   {
-    $return = $this->exec('git --git-dir=%s log %s --format="%s" -n1', array($gitDir, $commit, $format));
+    $return = $this->exec('git --git-dir=%s log %s --format=%s -n1', array($gitDir, $commit, $format));
     return (count($return)) ? $return[0] : '';
   }
 


### PR DESCRIPTION
Escaping is already handled by exec method.
