### PR TITLE
Symfony 1.x bug with php 5.4 fixed

### DIFF
--- a/lib/vendor/symfony/lib/config/sfApplicationConfiguration.class.php
+++ b/lib/vendor/symfony/lib/config/sfApplicationConfiguration.class.php
@@ -152,7 +152,7 @@ abstract class sfApplicationConfiguration extends ProjectConfiguration
     // compress output
     if (!self::$coreLoaded)
     {
-      ob_start(sfConfig::get('sf_compressed') ? 'ob_gzhandler' : '');
+      ob_start(sfConfig::get('sf_compressed') ? 'ob_gzhandler' : null);
     }
 
     self::$coreLoaded = true;

--- a/lib/vendor/symfony/lib/exception/sfException.class.php
+++ b/lib/vendor/symfony/lib/exception/sfException.class.php
@@ -100,7 +100,7 @@ class sfException extends Exception
         }
       }
 
-      ob_start(sfConfig::get('sf_compressed') ? 'ob_gzhandler' : '');
+      ob_start(sfConfig::get('sf_compressed') ? 'ob_gzhandler' : null);
 
       header('HTTP/1.0 500 Internal Server Error');
     }


### PR DESCRIPTION
http://stackoverflow.com/questions/10380932/php-warning-warning-ob-start-function-not-found-or-invalid-function-name
